### PR TITLE
[FEATURE] Raise a Gem Specific Error For Service Unavailable Case

### DIFF
--- a/lib/magento/base.rb
+++ b/lib/magento/base.rb
@@ -137,6 +137,9 @@ module MagentoAPI
   class SiteMovedPermanently < MagentoRuntimeError
   end
 
+  class ServiceUnavailable < MagentoRuntimeError
+  end
+
   class ApiError < StandardError
     attr_reader :code
 


### PR DESCRIPTION
## Summary
At the moment, when trying to connect to a Magento store and get a service unavailable error, the gem throws a generic Runtime error. We want to differentiate this error from generic RunTimeError, by identifying it, and wrapping it in a new specific error type so that applications using this gem would be able to capture it and handle it without confusing it a generic error at run time.